### PR TITLE
testing and failing json encoding of vlf fits_rec

### DIFF
--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -882,7 +882,7 @@ class DispatcherAPI:
         return d
 
     @staticmethod
-    def set_api_code(query_dict, url="www.astro.unige.ch/cdci/astrooda/dispatch-data"):
+    def set_api_code(query_dict, url="www.astro.unige.ch/mmoda/dispatch-data"):
 
         _skip_list_ = ['job_id', 'query_status',
                        'session_id', 'use_resolver[local]', 'use_scws']

--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -882,7 +882,7 @@ class DispatcherAPI:
         return d
 
     @staticmethod
-    def set_api_code(query_dict, url="www.astro.unige.ch/mmoda/dispatch-data"):
+    def set_api_code(query_dict, url="www.astro.unige.ch/cdci/astrooda/dispatch-data"):
 
         _skip_list_ = ['job_id', 'query_status',
                        'session_id', 'use_resolver[local]', 'use_scws']

--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -168,7 +168,7 @@ class DispatcherAPI:
                  ):
 
         if url is None:
-            url = "https://www.astro.unige.ch/cdci/astrooda/dispatch-data"
+            url = "https://www.astro.unige.ch/mmoda/dispatch-data"
 
         if host is not None:
             logger.warning(

--- a/oda_api/data_products.py
+++ b/oda_api/data_products.py
@@ -338,7 +338,7 @@ class NumpyDataUnit(object):
                     out_file = StringIO(pickled_data)
                     gzip_file = gzip.GzipFile(fileobj=out_file, mode='wb')
 
-                    gzip_file.write()
+                    gzip_file.write(pickled_data)
                     _binarys = base64.b64encode(out_file.getvalue())
                     gzip_file.close()
                 else:
@@ -347,7 +347,7 @@ class NumpyDataUnit(object):
                     )
 
             else:
-                _d= json.dumps(self.data, cls=JsonCustomEncoderPatched)
+                _d= json.dumps(self.data, cls=JsonCustomEncoder)
 
 
         _o_dict = {'data': _d,

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -51,7 +51,7 @@ def pick_scw(kind="any"):
     if kind == "crab":
         return "066500220010.001"
     elif kind == "any":
-        scwlist = requests.get("https://www.astro.unige.ch/cdci/astrooda/dispatch-data/"
+        scwlist = requests.get("https://www.astro.unige.ch/mmoda/dispatch-data/"
                                "gw/timesystem/api/v1.0/scwlist/cons/"
                                "2002-12-17T08:00:00/2020-12-21T08:00:00"
                                "?&ra=83&dec=22&radius=200.0&min_good_isgri=1000").json()


### PR DESCRIPTION
it is caused by [problem in astropy](https://github.com/astropy/astropy/pull/11957), encoding VLF column in FITS_rec . Jsonification in this case silently produces something quite different.
It happens currently only for OSA which uses newer heasoft, with `ftrbnrmf` always producing compressed rmf.
