### PR TITLE
default url with None

### DIFF
--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -169,7 +169,7 @@ class DispatcherAPI:
 
     def __init__(self,
                  instrument='mock',
-                 url="https://www.astro.unige.ch/mmoda/dispatch-data",
+                 url=None,
                  run_analysis_handle='run_analysis',
                  host=None,
                  port=None,
@@ -179,6 +179,9 @@ class DispatcherAPI:
                  n_max_tries=20,
                  session_id=None,
                  ):
+
+        if url is None:
+            url = "https://www.astro.unige.ch/mmoda/dispatch-data"
 
         if host is not None:
             msg = '\n'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,11 +11,11 @@ from cdci_data_analysis.pytest_fixtures import (
             dispatcher_long_living_fixture,
             default_token_payload,
         )
+
 def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
-
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runslow"):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,7 +22,6 @@ default_token_payload = dict(
     mssub=True
 )
 
-
 @pytest.mark.slow
 def test_show_product(dispatcher_live_fixture, capsys):
     with capsys.disabled():
@@ -105,6 +104,13 @@ data_collection = disp.get_product(**par_dict)
 '''
 
     assert output_api_code == expected_api_code or output_api_code == expected_api_code.replace('PRODUCTS_URL', 'http://0.0.0.0:8001')
+
+
+def test_default_url_init():
+    disp = oda_api.api.DispatcherAPI(
+        url=None
+    )
+    assert disp.url == "https://www.astro.unige.ch/mmoda/dispatch-data"
 
 
 @pytest.mark.parametrize("protocol_url", ['http://', 'https://', ''])

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -9,7 +9,6 @@ def test_remote_301_post():
     from oda_api.token import discover_token
 
     api_cat_str = '{"cat_frame": "fk5", "cat_coord_units": "deg", "cat_column_list": [[17, 87], ["GRS 1915+105", "MAXI J1820+070"], [29.396455764770508, 1803.1607666015625], [288.799560546875, 275.0911865234375], [10.939922332763672, 7.185144901275635], [-32768, -32768], [2, 2], [0, 0], [0.0002800000074785203, 0.00041666667675599456]], "cat_column_names": ["meta_ID", "src_names", "significance", "ra", "dec", "NEW_SOURCE", "ISGRI_FLAG", "FLAG", "ERR_RAD"], "cat_column_descr": [["meta_ID", "<i8"], ["src_names", "<U20"], ["significance", "<f8"], ["ra", "<f8"], ["dec", "<f8"], ["NEW_SOURCE", "<i8"], ["ISGRI_FLAG", "<i8"], ["FLAG", "<i8"], ["ERR_RAD", "|O"]], "cat_lat_name": "dec", "cat_lon_name": "ra"}'
-
     
     with pytest.raises(URLRedirected) as execinfo:
         disp = DispatcherAPI(url="http://www.astro.unige.ch/mmoda/dispatch-data")


### PR DESCRIPTION
this is easier to use because when I want to propagate a URL from elsewhere, I can propagate None and not add a condition on passing or not to `DispatcherAPI` constructor.
