### PR TITLE
Remove support dry run parameter

### DIFF
--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -419,6 +419,7 @@ class DispatcherAPI:
         mismatching_parameters = []
         for k in self.parameters_dict.keys():
             # these do not correspond to meaning
+            # TODO can it be removed from here too? This function to be used only within a test
             if k in ['query_status', 'off_line', 'verbose', 'dry_run']:                
                 continue
 

--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -419,8 +419,14 @@ class DispatcherAPI:
         mismatching_parameters = []
         for k in self.parameters_dict.keys():
             # these do not correspond to meaning
-            # TODO can it be removed from here too? This function to be used only within a test
-            if k in ['query_status', 'off_line', 'verbose', 'dry_run']:                
+            ''' 
+            The dry_run parameter is not actually considered within the oda_api,
+            but we keep it here for  consistency.
+            As discussed in: 
+            * https://github.com/oda-hub/oda_api/pull/85
+            * https://github.com/oda-hub/oda_api/issues/84
+            '''
+            if k in ['query_status', 'off_line', 'verbose', 'dry_run']:
                 continue
 
             returned = self.returned_analysis_parameters.get(k, None)

--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -852,7 +852,7 @@ class DispatcherAPI:
 
         if 'dry_run' in kwargs:
             warnings.warn('The dry_run parameter you included is not going to have any effect on the execution.\n'
-                          'However the oda_api will perform a check of the list opf valid parameters for your request.')
+                          'However the oda_api will perform a check of the list of valid parameters for your request.')
 
         res = requests.get("%s/api/par-names" % self.url, params=dict(
             instrument=instrument, product_type=product), cookies=self.cookies)

--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -853,6 +853,7 @@ class DispatcherAPI:
         if 'dry_run' in kwargs:
             warnings.warn('The dry_run parameter you included is not going to have any effect on the execution.\n'
                           'However the oda_api will perform a check of the list of valid parameters for your request.')
+            del kwargs['dry_run']
 
         res = requests.get("%s/api/par-names" % self.url, params=dict(
             instrument=instrument, product_type=product), cookies=self.cookies)
@@ -864,7 +865,6 @@ class DispatcherAPI:
             _ignore_list = ['instrument', 'product_type', 'query_type',
                             'off_line', 'query_status', 'verbose', 'session_id']
             validation_dict = copy.deepcopy(kwargs)
-
 
             for _i in _ignore_list:
                 del validation_dict[_i]

--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -823,7 +823,6 @@ class DispatcherAPI:
                     product: str,
                     instrument: str,
                     verbose=None,
-                    dry_run: bool = False,
                     product_type: str = 'Real',
                     **kwargs):
         """
@@ -843,7 +842,6 @@ class DispatcherAPI:
         kwargs['query_status'] = 'new',
         kwargs['verbose'] = verbose,
         kwargs['session_id'] = self.session_id
-        kwargs['dry_run'] = dry_run,
 
         res = requests.get("%s/api/par-names" % self.url, params=dict(
             instrument=instrument, product_type=product), cookies=self.cookies)
@@ -853,8 +851,9 @@ class DispatcherAPI:
                 'parameter check not available on remote server, check carefully parameters name')
         else:
             _ignore_list = ['instrument', 'product_type', 'query_type',
-                            'off_line', 'query_status', 'verbose', 'session_id', 'dry_run']
+                            'off_line', 'query_status', 'verbose', 'session_id']
             validation_dict = copy.deepcopy(kwargs)
+
 
             for _i in _ignore_list:
                 del validation_dict[_i]
@@ -903,18 +902,8 @@ class DispatcherAPI:
             raise RuntimeError(
                 "not failed, not, but complete? programming error for client!")
 
-        # <
-
-        data = None
-
-        if not dry_run:
-            d = DataCollection.from_response_json(
-                res_json, instrument, product)
-
-        else:
-            self._decode_res_json(
-                res.json()['products']['instrument_parameters'])
-            d = None
+        d = DataCollection.from_response_json(
+            res_json, instrument, product)
 
         del(res)
 

--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -850,6 +850,10 @@ class DispatcherAPI:
         kwargs['verbose'] = verbose,
         kwargs['session_id'] = self.session_id
 
+        if 'dry_run' in kwargs:
+            warnings.warn('The dry_run parameter you included is not going to have any effect on the execution.\n'
+                          'However the oda_api will perform a check of the list opf valid parameters for your request.')
+
         res = requests.get("%s/api/par-names" % self.url, params=dict(
             instrument=instrument, product_type=product), cookies=self.cookies)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -95,7 +95,6 @@ par_dict={{
     "product": "dummy",
     "product_type": "Dummy",
     "off_line": "False",
-    "dry_run": "False",
     "api": "True",
     "oda_api_version": "{oda_api.__version__}"
 }}
@@ -103,7 +102,7 @@ par_dict={{
 data_collection = disp.get_product(**par_dict)
 '''
 
-    assert output_api_code == expected_api_code or output_api_code == expected_api_code.replace('PRODUCTS_URL', 'http://0.0.0.0:8001')
+    assert output_api_code == expected_api_code or output_api_code == expected_api_code.replace('PRODUCTS_URL', dispatcher_api)
 
 
 def test_default_url_init():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -102,7 +102,7 @@ par_dict={{
 data_collection = disp.get_product(**par_dict)
 '''
 
-    assert output_api_code == expected_api_code or output_api_code == expected_api_code.replace('PRODUCTS_URL', dispatcher_api)
+    assert output_api_code == expected_api_code or output_api_code == expected_api_code.replace('PRODUCTS_URL', dispatcher_api.url)
 
 
 def test_default_url_init():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -139,10 +139,10 @@ def test_dry_run_param(dispatcher_api, dry_run_value):
     assert 'api_code' in jdata_output['prod_dictionary']
     output_api_code = jdata_output['prod_dictionary']['api_code']
 
-    if dry_run_value is not None and dry_run_value != 'not_included':
-        assert 'dry_run' in output_api_code
-    else:
-        assert 'dry_run' not in output_api_code
+    assert 'dry_run' not in output_api_code
+
+    assert 'analysis_parameters' in jdata_output['prod_dictionary']
+    assert 'dry_run' not in jdata_output['prod_dictionary']['analysis_parameters']
 
 
 def test_default_url_init():


### PR DESCRIPTION
Any mention of the `dry_run` is removed.

Ideally we could consider doing the same within the dispatcher