### PR TITLE
ordered dict before generating api_code

### DIFF
--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -925,9 +925,7 @@ class DispatcherAPI:
     @staticmethod
     def set_api_code(query_dict, url="www.astro.unige.ch/mmoda/dispatch-data"):
 
-        query_dict = OrderedDict({
-            k: query_dict[k] for k in sorted(query_dict.keys())
-        })
+        query_dict = OrderedDict(sorted(query_dict.items()))
 
         _skip_list_ = ['job_id', 'query_status',
                        'session_id', 'use_resolver[local]', 'use_scws']

--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -1,5 +1,7 @@
 
 from __future__ import absolute_import, division, print_function
+
+from collections import OrderedDict
 from json.decoder import JSONDecodeError
 from astropy.table import Table
 from .data_products import NumpyDataProduct, BinaryData, ApiCatalog
@@ -922,6 +924,10 @@ class DispatcherAPI:
 
     @staticmethod
     def set_api_code(query_dict, url="www.astro.unige.ch/mmoda/dispatch-data"):
+
+        query_dict = OrderedDict({
+            k: query_dict[k] for k in sorted(query_dict.keys())
+        })
 
         _skip_list_ = ['job_id', 'query_status',
                        'session_id', 'use_resolver[local]', 'use_scws']

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -91,18 +91,18 @@ def test_oda_api_code(dispatcher_api):
 disp=DispatcherAPI(url='PRODUCTS_URL/dispatch-data', instrument='mock')
 
 par_dict={{
+    "DEC": -29.74516667,
+    "RA": 265.97845833,
+    "T1": "2017-03-06T13:26:48.000",
+    "T2": "2017-03-06T15:32:27.000",
+    "api": "True",
     "instrument": "empty",
+    "oda_api_version": "{oda_api.__version__}",
+    "off_line": "False",
+    "p_list": [],
     "product": "dummy",
     "product_type": "Dummy",
-    "off_line": "False",
-    "api": "True",
-    "oda_api_version": "{oda_api.__version__}",
-    "p_list": [],
-    "src_name": "1E 1740.7-2942",
-    "RA": 265.97845833,
-    "DEC": -29.74516667,
-    "T1": "2017-03-06T13:26:48.000",
-    "T2": "2017-03-06T15:32:27.000"
+    "src_name": "1E 1740.7-2942"
 }}
 
 data_collection = disp.get_product(**par_dict)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -87,7 +87,7 @@ def test_instruments():
         host=get_platform_dispatcher(),
         instrument="mock",
     )
-    assert disp.get_instruments_list() == ['isgri', 'jemx', 'polar', 'spi_acs']
+    assert disp.get_instruments_list() == ['magic', 'isgri', 'jemx', 'polar', 'antares', 'spi_acs']
 
 
 def test_instrument_description_not_null():


### PR DESCRIPTION
thought might be useful considering the changes applied with 

[https://github.com/oda-hub/dispatcher-app/pull/254](https://github.com/oda-hub/dispatcher-app/pull/254)