### PR TITLE
Enforce label

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,15 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.1.0
+      with:
+        REQUIRED_LABELS_ANY: "test-live"
+        #REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','skip-changelog']"
+        #BANNED_LABELS: "test-only-fast"
+

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,15 +1,15 @@
-name: Enforce PR labels
+# name: Enforce PR labels
 
-on:
-  pull_request:
-    types: [labeled, unlabeled, opened, edited, synchronize]
-jobs:
-  enforce-label:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: yogevbd/enforce-label-action@2.1.0
-      with:
-        REQUIRED_LABELS_ANY: "test-live"
-        #REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','skip-changelog']"
-        #BANNED_LABELS: "test-only-fast"
+# on:
+#   pull_request:
+#     types: [labeled, unlabeled, opened, edited, synchronize]
+# jobs:
+#   enforce-label:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: yogevbd/enforce-label-action@2.1.0
+#       with:
+#         REQUIRED_LABELS_ANY: "test-live"
+#         #REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','skip-changelog']"
+#         #BANNED_LABELS: "test-only-fast"
 

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,15 +1,15 @@
-# name: Enforce PR labels
+name: Enforce PR labels
 
-# on:
-#   pull_request:
-#     types: [labeled, unlabeled, opened, edited, synchronize]
-# jobs:
-#   enforce-label:
-#     runs-on: ubuntu-latest
-#     steps:
-#     - uses: yogevbd/enforce-label-action@2.1.0
-#       with:
-#         REQUIRED_LABELS_ANY: "test-live"
-#         #REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','skip-changelog']"
-#         #BANNED_LABELS: "test-only-fast"
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.1.0
+      with:
+        REQUIRED_LABELS_ANY: "test-live"
+        #REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','skip-changelog']"
+        #BANNED_LABELS: "test-only-fast"
 


### PR DESCRIPTION
this will ensure that we know, in the future, which PR breaks the live test (if any, it can also break because of the remote server, but this is exceptional).

edit: I changed this to master. So that we check if it failed before #109 . In any case, it's suspicious that #109  changes the same module as the breaking test uses (plot_tools)