### PR TITLE
change instr-list endpoint 

### DIFF
--- a/oda_api/api.py
+++ b/oda_api/api.py
@@ -959,7 +959,7 @@ class DispatcherAPI:
     @safe_run
     def get_instruments_list(self):
         # print ('instr',self.instrument)
-        res = requests.get("%s/api/instr-list" % self.url,
+        res = requests.get("%s/instr-list" % self.url,
                            params=dict(instrument=self.instrument), cookies=self.cookies)
 
         if res.status_code != 200:


### PR DESCRIPTION
Fixes #189 

There are also either /api/meta-data or /meta-data endpoints in dispather, which are currently equivalent. Is one meant to be deprecated? 