### PR TITLE
Restrict matplotlib version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "future",
     "astropy>=3.2,<=6.1.4",
     "json_tricks",
-    "matplotlib",
+    "matplotlib<3.10",
     "numpy<2.0",
     "jsonschema",
     "pyjwt",


### PR DESCRIPTION
There is an [incompatibility](https://github.com/astropy/astropy/pull/17144) between `astropy` and recent `matplotlib`. 
It seems that a fix for this incompatibility hasn't been backported to the versions of `astropy` we rely on (`astropy` is currently restricted in our dependencies). 
It hasn't been observed directly with `oda_api` itself, but @andriineronov  encountered a problem in the environment where `gammapy` is also present. So to be on a safe side, I propose to restrict it as well.
NOTE: don't forget to restrict in conda package as well. 
